### PR TITLE
IN-38 Set explicit artifact retention duration to avoid filling up the whole GH storage

### DIFF
--- a/.github/workflows/publish_binaries.yml
+++ b/.github/workflows/publish_binaries.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           name: client-bin-${{ matrix.board.target }}
           path: src/PV260.Client.ConsoleApp/publish/*
+          retention-days: 1
 
   server:
     strategy:
@@ -85,6 +86,7 @@ jobs:
         with:
           name: server-bin-${{ matrix.board.target }}
           path: src/PV260.API.App/publish/*.zip
+          retention-days: 1
 
   release:
     runs-on: self-hosted


### PR DESCRIPTION
# Jira item
IN-38

# Description
Add retention-days option to artifacts published by GitHub Actions workflows to ensure they are being deleted quickly enough to avoid filling up all storage provided by GitHub.