### PR TITLE
IN-51 Separate report generation to own service and implement retry logic

### DIFF
--- a/src/PV260.API.App/PV260.API.App.csproj
+++ b/src/PV260.API.App/PV260.API.App.csproj
@@ -8,7 +8,10 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PV260.API.App/Program.cs
+++ b/src/PV260.API.App/Program.cs
@@ -4,6 +4,7 @@ using PV260.API.DAL.Extensions;
 using PV260.API.DAL.Migrator;
 using PV260.API.DAL.Options;
 using PV260.API.Infrastructure.Extensions;
+using PV260.API.Presentation.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.Configure<DalOptions>(builder.Configuration.GetSection("DalSettings"));
@@ -14,9 +15,11 @@ builder.Services.Configure<EmailOptions>(builder.Configuration.GetSection("Email
 builder.Services.AddControllers();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddDalServices();
-builder.Services.AddDBlServices();
-builder.Services.AddInfrastructureServices();
+builder.Services
+    .AddDalServices()
+    .AddDBlServices()
+    .AddInfrastructureServices()
+    .AddPresentationServices();
 
 var app = builder.Build();
 

--- a/src/PV260.API.BL/Facades/IReportFacade.cs
+++ b/src/PV260.API.BL/Facades/IReportFacade.cs
@@ -27,9 +27,9 @@ public interface IReportFacade : ICrudFacade<ReportListModel, ReportDetailModel,
     Task<ReportDetailModel?> GetLatestAsync();
 
     /// <summary>
-    /// Generates a new report by downloading the latest data from ARK Funds and comparing it with the previous report.
+    /// Generates new report, saves it to the database and sends it via email if configured.
     /// </summary>
-    /// <returns>The newly generated report.</returns>
+    /// <returns>New report</returns>
     Task<ReportDetailModel> GenerateReportAsync();
 
     /// <summary>

--- a/src/PV260.API.BL/PV260.API.BL.csproj
+++ b/src/PV260.API.BL/PV260.API.BL.csproj
@@ -9,8 +9,8 @@
     <ItemGroup>
       <PackageReference Include="Coravel" Version="6.0.2" />
       <PackageReference Include="CsvHelper" Version="33.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PV260.API.BL/Services/IReportService.cs
+++ b/src/PV260.API.BL/Services/IReportService.cs
@@ -1,0 +1,15 @@
+﻿using PV260.Common.Models;
+
+namespace PV260.API.BL.Services;
+
+/// <summary>
+/// Service for generating stock reports.
+/// </summary>
+public interface IReportService
+{
+    /// <summary>
+    /// Generates new report.
+    /// </summary>
+    /// <returns>New report</returns>
+    Task<ReportDetailModel> GenerateNewReportAsync(ReportDetailModel? latestReport);
+}

--- a/src/PV260.API.DAL/PV260.API.DAL.csproj
+++ b/src/PV260.API.DAL/PV260.API.DAL.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PV260.API.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PV260.API.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using Coravel;
 using Microsoft.Extensions.DependencyInjection;
-using PV260.API.BL.Facades;
 using PV260.API.BL.Services;
-using PV260.API.Infrastructure.Facades;
 using PV260.API.Infrastructure.Invocables;
 using PV260.API.Infrastructure.Services;
 
@@ -14,10 +12,6 @@ public static class ServiceCollectionExtensions
     {
         // Services
         serviceCollection.AddSingleton<IEmailService, SendgridEmailService>();
-        
-        // Facades
-        serviceCollection.AddSingleton<IReportFacade, ReportFacade>();
-        serviceCollection.AddSingleton<IEmailFacade, EmailRecipientFacade>();
         
         // Invocables
         serviceCollection.AddTransient<GenerateReportInvocable>();

--- a/src/PV260.API.Infrastructure/Invocables/DeleteOldReportsInvocable.cs
+++ b/src/PV260.API.Infrastructure/Invocables/DeleteOldReportsInvocable.cs
@@ -1,6 +1,7 @@
 ﻿using Coravel.Invocable;
 using Microsoft.Extensions.Logging;
 using PV260.API.BL.Facades;
+using PV260.API.Presentation.Facades;
 
 namespace PV260.API.Infrastructure.Invocables;
 

--- a/src/PV260.API.Infrastructure/Invocables/GenerateReportInvocable.cs
+++ b/src/PV260.API.Infrastructure/Invocables/GenerateReportInvocable.cs
@@ -1,6 +1,7 @@
 ﻿using Coravel.Invocable;
 using Microsoft.Extensions.Logging;
 using PV260.API.BL.Facades;
+using PV260.API.Presentation.Facades;
 
 namespace PV260.API.Infrastructure.Invocables;
 

--- a/src/PV260.API.Infrastructure/PV260.API.Infrastructure.csproj
+++ b/src/PV260.API.Infrastructure/PV260.API.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\PV260.API.BL\PV260.API.BL.csproj" />
+      <ProjectReference Include="..\PV260.API.Presentation\PV260.API.Presentation.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/PV260.API.Infrastructure/PV260.API.Infrastructure.csproj
+++ b/src/PV260.API.Infrastructure/PV260.API.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Coravel" Version="6.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
       <PackageReference Include="SendGrid" Version="9.29.3" />
     </ItemGroup>
 

--- a/src/PV260.API.Infrastructure/Services/ArkFundsReportService.cs
+++ b/src/PV260.API.Infrastructure/Services/ArkFundsReportService.cs
@@ -1,0 +1,121 @@
+﻿using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using PV260.API.BL.Options;
+using PV260.API.BL.Services;
+using PV260.Common.Models;
+
+namespace PV260.API.Infrastructure.Services;
+
+/// <summary>
+/// Implementation of IReportService based on ARK funds data.
+/// </summary>
+public class ArkFundsReportService(
+    HttpClient httpClient,
+    IOptions<ReportOptions> reportOptions,
+    ILogger<ArkFundsReportService> logger) : IReportService
+{
+    private readonly ReportOptions _reportOptions = reportOptions.Value;
+    
+    /// <inheritdoc />
+    public async Task<ReportDetailModel> GenerateNewReportAsync(ReportDetailModel? latestReport)
+    {
+        var csvData = await httpClient.GetStringAsync(_reportOptions.ArkFundsCsvUrl);
+        
+        var latestRecords = latestReport?.Records.ToDictionary(record => record.Ticker) ?? [];
+        var reportRecords = await ParseCsvData(csvData, latestRecords);
+        
+        return CreateReportDetail(reportRecords);
+    }
+    
+    private async Task<List<ReportRecordModel>> ParseCsvData(string csvData,Dictionary<string, ReportRecordModel> latestRecords)
+    {
+        var reportRecords = new List<ReportRecordModel>();
+        using var reader = new StringReader(csvData);
+        using var csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HasHeaderRecord = true,
+            MissingFieldFound = null
+        });
+        
+        await csv.ReadAsync();
+        csv.ReadHeader();
+        
+        var currentTickers = new HashSet<string>();
+
+        while (await csv.ReadAsync())
+        {
+            if (IsEndOfRelevantData(csv))
+            {
+                break;
+            }
+
+            var ticker = csv.GetField<string>("ticker");
+            if (ticker == null) continue;
+            currentTickers.Add(ticker);
+            var record = CreateReportRecord(csv, ticker, latestRecords);
+            reportRecords.Add(record);
+        }
+        
+        AddMissingTickerRecords(latestRecords, currentTickers, reportRecords);
+        return reportRecords;
+    }
+    
+    private ReportRecordModel CreateReportRecord(CsvReader csv, string ticker, Dictionary<string, ReportRecordModel> latestRecords)
+    {
+        var sharesField = csv.GetField<string>("shares") ?? "-1";
+        var numberOfShares = int.Parse(sharesField.Replace(",", ""));
+        var sharesChangePercentage = numberOfShares == -1 ? 0 : CalculateSharesChangePercentage(ticker, numberOfShares, latestRecords);
+
+        return new ReportRecordModel
+        {
+            CompanyName = csv.GetField<string>("company") ?? "Missing Company name",
+            Ticker = ticker,
+            NumberOfShares = numberOfShares,
+            SharesChangePercentage = sharesChangePercentage,
+            Weight = double.Parse((csv.GetField<string>("weight (%)") ?? "").Replace("%", "").Trim())
+        };
+    }
+    
+    private double CalculateSharesChangePercentage(string ticker, int numberOfShares, Dictionary<string, ReportRecordModel> latestRecords)
+    {
+        if (!latestRecords.TryGetValue(ticker, out var latestRecord) || latestRecord.NumberOfShares <= 0)
+            return 0;
+        
+        logger.LogDebug("Ticker: {Ticker}, Latest Shares: {LatestShares}, Current Shares: {CurrentShares}", ticker, latestRecord.NumberOfShares, numberOfShares);
+        return (double)(numberOfShares - latestRecord.NumberOfShares) / latestRecord.NumberOfShares * 100;
+
+    }
+    
+    private static bool IsEndOfRelevantData(CsvReader csv)
+    {
+        return csv.Context.Parser?.RawRecord.Contains("Investors") ?? false;
+    }
+    
+    private static void AddMissingTickerRecords(Dictionary<string, ReportRecordModel> latestRecords, HashSet<string> currentTickers, List<ReportRecordModel> reportRecords)
+    {
+        reportRecords.AddRange(from latestTicker in latestRecords.Keys
+            where !currentTickers.Contains(latestTicker)
+            let latestRecord = latestRecords[latestTicker]
+            select new ReportRecordModel
+            {
+                CompanyName = latestRecord.CompanyName,
+                Ticker = latestTicker,
+                NumberOfShares = 0,
+                SharesChangePercentage = -100,
+                Weight = 0
+            });
+    }
+    
+    private ReportDetailModel CreateReportDetail(List<ReportRecordModel> reportRecords)
+    {
+        return new ReportDetailModel
+        {
+            Name = $"ARK Innovation ETF Report - {DateTime.UtcNow:yyyy-MM-dd}",
+            CreatedAt = DateTime.UtcNow,
+            Records = reportRecords
+        };
+    }
+}

--- a/src/PV260.API.Presentation/Controllers/EmailController.cs
+++ b/src/PV260.API.Presentation/Controllers/EmailController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using PV260.API.BL.Facades;
+using PV260.API.Presentation.Facades;
 using PV260.Common.Models;
 
 namespace PV260.API.Presentation.Controllers;

--- a/src/PV260.API.Presentation/Controllers/ReportController.cs
+++ b/src/PV260.API.Presentation/Controllers/ReportController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using PV260.API.BL.Facades;
+using PV260.API.Presentation.Facades;
 using PV260.Common.Models;
 
 namespace PV260.API.Presentation.Controllers;

--- a/src/PV260.API.Presentation/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PV260.API.Presentation/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using PV260.API.BL.Facades;
+using PV260.API.Presentation.Facades;
+
+namespace PV260.API.Presentation.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddPresentationServices(this IServiceCollection serviceCollection)
+    {
+        // Facades
+        serviceCollection.AddSingleton<IReportFacade, ReportFacade>();
+        serviceCollection.AddSingleton<IEmailFacade, EmailRecipientFacade>();
+
+        return serviceCollection;
+    }
+}

--- a/src/PV260.API.Presentation/Facades/CrudFacadeBase.cs
+++ b/src/PV260.API.Presentation/Facades/CrudFacadeBase.cs
@@ -5,7 +5,7 @@ using PV260.API.DAL.Entities;
 using PV260.API.DAL.UnitOfWork;
 using PV260.Common.Models;
 
-namespace PV260.API.Infrastructure.Facades;
+namespace PV260.API.Presentation.Facades;
 
 /// <summary>
 /// Provides a base implementation for CRUD operations in a facade.

--- a/src/PV260.API.Presentation/Facades/EmailRecipientFacade.cs
+++ b/src/PV260.API.Presentation/Facades/EmailRecipientFacade.cs
@@ -5,7 +5,7 @@ using PV260.API.DAL.Entities;
 using PV260.API.DAL.UnitOfWork;
 using PV260.Common.Models;
 
-namespace PV260.API.Infrastructure.Facades;
+namespace PV260.API.Presentation.Facades;
 
 /// <inheritdoc />
 public class EmailRecipientFacade(

--- a/src/PV260.API.Presentation/Facades/ReportFacade.cs
+++ b/src/PV260.API.Presentation/Facades/ReportFacade.cs
@@ -21,6 +21,7 @@ public class ReportFacade(
     IOptions<EmailOptions> emailOptions,
     IEmailFacade emailFacade,
     IEmailService emailService,
+    IReportService reportService,
     ILogger<ReportFacade> logger)
     : CrudFacadeBase<ReportListModel, ReportDetailModel, ReportEntity>(reportMapper, unitOfWorkFactory), IReportFacade
 {
@@ -29,8 +30,6 @@ public class ReportFacade(
     private const string ReportRecordsPlaceholder = "{ReportRecords}";
     
     private readonly IMapper<ReportEntity, ReportListModel, ReportDetailModel> _reportMapper = reportMapper;
-    private readonly IEmailFacade _emailFacade = emailFacade;
-    private readonly IEmailService _emailService = emailService;
     private readonly ReportOptions _reportOptions = reportOptions.Value;
     private readonly EmailOptions _emailOptions = emailOptions.Value;
 
@@ -100,10 +99,7 @@ public class ReportFacade(
         await unitOfWork.CommitAsync();
     }
     
-    /// <summary>
-    /// Gets the last generated report
-    /// </summary>
-    /// <returns>The last generated report</returns>
+    /// <inheritdoc />
     public async Task<ReportDetailModel?> GetLatestAsync()
     {
         await using var uow = UnitOfWorkFactory.Create();
@@ -125,14 +121,13 @@ public class ReportFacade(
 
         foreach (var report in reports)
             uow.GetRepository<ReportEntity>().Delete(report);
+        
+        logger.LogInformation("Deleted all ({Count}) reports", reports.Count);
 
         await uow.CommitAsync();
     }
 
-    /// <summary>
-    /// Deletes reports that are older than the configured retention period.
-    /// </summary>
-    /// <returns>The number of reports deleted.</returns>
+    /// <inheritdoc />
     public async Task<int> DeleteOldReportsAsync()
     {
         var cutoffDate = DateTime.UtcNow.AddDays(-_reportOptions.ReportDaysToKeep);
@@ -142,33 +137,31 @@ public class ReportFacade(
             .Get()
             .Where(r => r.CreatedAt < cutoffDate)
             .ToListAsync();
-
-        foreach (var report in reports)
-        {
-            uow.GetRepository<ReportEntity>().Delete(report);
-        }
-
+        
+        uow.GetRepository<ReportEntity>().DeleteRange(reports);
         await uow.CommitAsync();
+        
+        logger.LogInformation("Deleted {Count} old reports older than {CutoffDate}", reports.Count, cutoffDate);
+        
         return reports.Count;
     }
 
-    /// <summary>
-    /// Generates new report by fetching data from the specified CSV URL.
-    /// </summary>
-    /// <returns>New report</returns>
+    /// <inheritdoc />
     public async Task<ReportDetailModel> GenerateReportAsync()
     {
-        logger.LogDebug("Generating new report. Source: {ArkFundsCsvUrl}", _reportOptions.ArkFundsCsvUrl);
+        var latestReport = await GetLatestAsync();
+        var report = await reportService.GenerateNewReportAsync(latestReport);
+        await SaveAsync(report);
         
-        using var httpClient = new HttpClient();
-        var csvData = await httpClient.GetStringAsync(_reportOptions.ArkFundsCsvUrl);
-
-        var reportRecords = await ParseCsvData(csvData);
-
-        var reportDetail = CreateReportDetail(reportRecords);
-
-        await SaveAsync(reportDetail);
-        return reportDetail;
+        logger.LogInformation("Generated new report with ID {ReportId}", report.Id);
+        
+        if (_reportOptions.SendEmailOnReportGeneration)
+        {
+            await SendReportViaEmailAsync(report.Id);
+            logger.LogInformation("Sent report with ID {ReportId} via email", report.Id);
+        }
+        
+        return report;
     }
 
     /// <inheritdoc />
@@ -178,7 +171,7 @@ public class ReportFacade(
         if (report is null)
             throw new InvalidOperationException($"Report with ID {reportId} was not found.");
         
-        var recipients = await _emailFacade.GetAllEmailRecipientsAsync();
+        var recipients = await emailFacade.GetAllEmailRecipientsAsync();
         if (recipients.Count == 0)
             return;
 
@@ -196,109 +189,6 @@ public class ReportFacade(
             .Replace(ReportTimestampPlaceholder, report.CreatedAt.ToString("g"))
             .Replace(ReportRecordsPlaceholder, recordsText);
 
-        await _emailService.SendEmailAsync(recipients.Select(recipient => recipient.EmailAddress).ToList(), emailSubject, emailBody);
+        await emailService.SendEmailAsync(recipients.Select(recipient => recipient.EmailAddress).ToList(), emailSubject, emailBody);
     }
-
-    #region Report Generation
-
-    private async Task<List<ReportRecordModel>> ParseCsvData(string csvData)
-    {
-        var reportRecords = new List<ReportRecordModel>();
-        using var reader = new StringReader(csvData);
-        using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
-
-        await csv.ReadAsync();
-        csv.ReadHeader();
-
-        var latestReport = await GetLatestAsync();
-        var latestRecords = latestReport?.Records?.ToDictionary(r => r.Ticker) ?? new Dictionary<string, ReportRecordModel>();
-
-        var currentTickers = new HashSet<string>();
-
-        while (await csv.ReadAsync())
-        {
-            if (IsEndOfRelevantData(csv))
-            {
-                break;
-            }
-
-            var ticker = csv.GetField<string>("ticker");
-            if (ticker != null)
-            {
-                currentTickers.Add(ticker);
-                var record = CreateReportRecord(csv, ticker, latestRecords);
-                reportRecords.Add(record);
-            }
-        }
-
-        AddMissingTickerRecords(latestRecords, currentTickers, reportRecords);
-
-        return reportRecords;
-    }
-
-    private ReportRecordModel CreateReportRecord(CsvReader csv, string ticker, Dictionary<string, ReportRecordModel> latestRecords)
-    {
-        var sharesField = csv.GetField<string>("shares") ?? "-1";
-        var numberOfShares = int.Parse(sharesField.Replace(",", ""));
-        var sharesChangePercentage = numberOfShares == -1 ? 0 : CalculateSharesChangePercentage(ticker, numberOfShares, latestRecords);
-
-        return new ReportRecordModel
-        {
-            CompanyName = csv.GetField<string>("company") ?? "Missing Company name",
-            Ticker = ticker,
-            NumberOfShares = numberOfShares,
-            SharesChangePercentage = sharesChangePercentage,
-            Weight = double.Parse((csv.GetField<string>("weight (%)") ?? "").Replace("%", "").Trim())
-        };
-    }
-
-    private double CalculateSharesChangePercentage(string ticker, int numberOfShares, Dictionary<string, ReportRecordModel> latestRecords)
-    {
-        if (latestRecords.TryGetValue(ticker, out var latestRecord) && latestRecord.NumberOfShares > 0)
-        {
-            logger.LogDebug("Ticker: {Ticker}, Latest Shares: {LatestShares}, Current Shares: {CurrentShares}", ticker, latestRecord.NumberOfShares, numberOfShares);
-            return (double)(numberOfShares - latestRecord.NumberOfShares) / latestRecord.NumberOfShares * 100;
-        }
-        
-        return 0;
-    }
-    
-    private static bool IsEndOfRelevantData(CsvReader csv)
-    {
-        return csv.Context.Parser?.RawRecord.Contains("Investors") ?? false;
-    }
-
-    private static void AddMissingTickerRecords(Dictionary<string, ReportRecordModel> latestRecords, HashSet<string> currentTickers, List<ReportRecordModel> reportRecords)
-    {
-        foreach (var latestTicker in latestRecords.Keys)
-        {
-            if (currentTickers.Contains(latestTicker))
-            {
-                continue;
-            }
-
-            var latestRecord = latestRecords[latestTicker];
-            var record = new ReportRecordModel
-            {
-                CompanyName = latestRecord.CompanyName,
-                Ticker = latestTicker,
-                NumberOfShares = 0,
-                SharesChangePercentage = -100,
-                Weight = 0
-            };
-            reportRecords.Add(record);
-        }
-    }
-
-    private ReportDetailModel CreateReportDetail(List<ReportRecordModel> reportRecords)
-    {
-        return new ReportDetailModel
-        {
-            Name = $"ARK Innovation ETF Report - {DateTime.UtcNow:yyyy-MM-dd}",
-            CreatedAt = DateTime.UtcNow,
-            Records = reportRecords
-        };
-    }
-    
-    #endregion
 }

--- a/src/PV260.API.Presentation/Facades/ReportFacade.cs
+++ b/src/PV260.API.Presentation/Facades/ReportFacade.cs
@@ -11,7 +11,7 @@ using PV260.API.DAL.Entities;
 using PV260.API.DAL.UnitOfWork;
 using PV260.Common.Models;
 
-namespace PV260.API.Infrastructure.Facades;
+namespace PV260.API.Presentation.Facades;
 
 /// <inheritdoc cref="IReportFacade"/>
 public class ReportFacade(

--- a/src/PV260.API.Tests/FacadeTests/FacadeTestBase.cs
+++ b/src/PV260.API.Tests/FacadeTests/FacadeTestBase.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging.Abstractions;
-using PV260.API.BL.Facades;
 using PV260.API.BL.Mappers;
 using PV260.API.DAL.Entities;
 using PV260.API.DAL.UnitOfWork;
@@ -9,9 +8,10 @@ using PV260.Common.Models;
 using Testcontainers.MsSql;
 using Microsoft.Extensions.Options;
 using Moq;
+using PV260.API.BL.Facades;
 using PV260.API.BL.Options;
 using PV260.API.BL.Services;
-using PV260.API.Infrastructure.Facades;
+using PV260.API.Presentation.Facades;
 
 namespace PV260.API.Tests.FacadeTests;
 

--- a/src/PV260.Client.BL/PV260.Client.BL.csproj
+++ b/src/PV260.Client.BL/PV260.Client.BL.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 	
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
       <PackageReference Include="Polly" Version="8.5.2" />
       <PackageReference Include="Polly.Extensions" Version="8.5.2" />
     </ItemGroup>

--- a/src/PV260.Client.ConsoleApp/PV260.Client.ConsoleApp.csproj
+++ b/src/PV260.Client.ConsoleApp/PV260.Client.ConsoleApp.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
 		<PackageReference Include="Spectre.Console" Version="0.50.0" />
 		<PackageReference Include="Terminal.Gui" Version="1.18.1" />
     </ItemGroup>

--- a/src/PV260.Common/PV260.Common.csproj
+++ b/src/PV260.Common/PV260.Common.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-      <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.5" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Jira Item
IN-51

## Description
This PR adds timeout retry logic using Polly when accessing 3rd party API during report generation.
It also separates the generation logic to own service (which will have its own unit tests when IN-52 is done) and moves facade implementations to the Presentation layer.